### PR TITLE
revert back to KDE platform 5.10

### DIFF
--- a/com.ozmartians.VidCutter.json
+++ b/com.ozmartians.VidCutter.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.ozmartians.VidCutter",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.11",
+    "runtime-version": "5.10",
     "sdk": "org.kde.Sdk",
     "command": "vidcutter",
     "finish-args": [


### PR DESCRIPTION
file save dialog and portal calls cause a segfault at the moment, most likely due to PyQt5 still at 5.10.1 (i.e. not updated to 5.11 yet). tested against 5.10 platform version and save dialog working again so revert platform version back until PyQt5 module is updated upstream...

future note, always ensure PyQt5 module version is aligned with Qt5 backend version